### PR TITLE
Add struct type to GraphQL specification

### DIFF
--- a/cspell.yml
+++ b/cspell.yml
@@ -9,6 +9,7 @@ words:
   - monospace
   - openwebfoundation
   - parallelization
+  - struct
   - structs
   - subselection
   # Fictional characters / examples

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
     },
     "node_modules/@babel/code-frame": {
       "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
       "integrity": "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==",
       "dev": true,
       "dependencies": {
@@ -28,7 +27,6 @@
     },
     "node_modules/@babel/helper-validator-identifier": {
       "version": "7.14.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz",
       "integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g==",
       "dev": true,
       "engines": {
@@ -37,7 +35,6 @@
     },
     "node_modules/@babel/highlight": {
       "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
       "integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
       "dev": true,
       "dependencies": {
@@ -51,7 +48,6 @@
     },
     "node_modules/@babel/highlight/node_modules/ansi-styles": {
       "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
       "dev": true,
       "dependencies": {
@@ -63,7 +59,6 @@
     },
     "node_modules/@babel/highlight/node_modules/chalk": {
       "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
       "dev": true,
       "dependencies": {
@@ -77,7 +72,6 @@
     },
     "node_modules/@babel/highlight/node_modules/color-convert": {
       "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
       "dev": true,
       "dependencies": {
@@ -86,13 +80,11 @@
     },
     "node_modules/@babel/highlight/node_modules/color-name": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
     "node_modules/@cspell/cspell-bundled-dicts": {
       "version": "5.9.1",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-bundled-dicts/-/cspell-bundled-dicts-5.9.1.tgz",
       "integrity": "sha512-xnLHhqb5BdfnVrLDZIdfPKlsNt4OKgvWx6T/MpS5pC7/Unqjcj3Do1fVDNlJ/nmxWkWPJnWDc6c6yQWC1kEnuw==",
       "dev": true,
       "dependencies": {
@@ -138,7 +130,6 @@
     },
     "node_modules/@cspell/cspell-types": {
       "version": "5.9.1",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-types/-/cspell-types-5.9.1.tgz",
       "integrity": "sha512-h8CWnGAKtItJG5FkoD+6BICfH7LqLi1GdiiF6IP1ZcRbWFybmgV/Y8Vj7KvKlkG7enw3IIJKHln4UxFB7UV5qw==",
       "dev": true,
       "engines": {
@@ -147,229 +138,191 @@
     },
     "node_modules/@cspell/dict-ada": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-ada/-/dict-ada-1.1.2.tgz",
       "integrity": "sha512-UDrcYcKIVyXDz5mInJabRNQpJoehjBFvja5W+GQyu9pGcx3BS3cAU8mWENstGR0Qc/iFTxB010qwF8F3cHA/aA==",
       "dev": true
     },
     "node_modules/@cspell/dict-aws": {
       "version": "1.0.14",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-aws/-/dict-aws-1.0.14.tgz",
       "integrity": "sha512-K21CfB4ZpKYwwDQiPfic2zJA/uxkbsd4IQGejEvDAhE3z8wBs6g6BwwqdVO767M9NgZqc021yAVpr79N5pWe3w==",
       "dev": true
     },
     "node_modules/@cspell/dict-bash": {
       "version": "1.0.15",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-bash/-/dict-bash-1.0.15.tgz",
       "integrity": "sha512-rY5Bq4RWTgJTioG8vqFbCmnalc/UEM+iBuAZBYvBfT3nU/6SN00Zjyvlh823ir2ODkUryT29CwRYwXcPnuM04w==",
       "dev": true
     },
     "node_modules/@cspell/dict-companies": {
       "version": "1.0.40",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-companies/-/dict-companies-1.0.40.tgz",
       "integrity": "sha512-Aw07qiTroqSST2P5joSrC4uOA05zTXzI2wMb+me3q4Davv1D9sCkzXY0TGoC2vzhNv5ooemRi9KATGaBSdU1sw==",
       "dev": true
     },
     "node_modules/@cspell/dict-cpp": {
       "version": "1.1.40",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-cpp/-/dict-cpp-1.1.40.tgz",
       "integrity": "sha512-sscfB3woNDNj60/yGXAdwNtIRWZ89y35xnIaJVDMk5TPMMpaDvuk0a34iOPIq0g4V+Y8e3RyAg71SH6ADwSjGw==",
       "dev": true
     },
     "node_modules/@cspell/dict-cryptocurrencies": {
       "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-cryptocurrencies/-/dict-cryptocurrencies-1.0.10.tgz",
       "integrity": "sha512-47ABvDJOkaST/rXipNMfNvneHUzASvmL6K/CbOFpYKfsd0x23Jc9k1yaOC7JAm82XSC/8a7+3Yu+Fk2jVJNnsA==",
       "dev": true
     },
     "node_modules/@cspell/dict-csharp": {
       "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-csharp/-/dict-csharp-1.0.11.tgz",
       "integrity": "sha512-nub+ZCiTgmT87O+swI+FIAzNwaZPWUGckJU4GN402wBq420V+F4ZFqNV7dVALJrGaWH7LvADRtJxi6cZVHJKeA==",
       "dev": true
     },
     "node_modules/@cspell/dict-css": {
       "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-css/-/dict-css-1.0.12.tgz",
       "integrity": "sha512-K6yuxej7n454O7dwKG6lHacHrAOMZ0PhMEbmV6qH2JH0U4TtWXfBASYugHvXZCDDx1UObpiJP+3tQJiBqfGpHA==",
       "dev": true
     },
     "node_modules/@cspell/dict-django": {
       "version": "1.0.26",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-django/-/dict-django-1.0.26.tgz",
       "integrity": "sha512-mn9bd7Et1L2zuibc08GVHTiD2Go3/hdjyX5KLukXDklBkq06r+tb0OtKtf1zKodtFDTIaYekGADhNhA6AnKLkg==",
       "dev": true
     },
     "node_modules/@cspell/dict-dotnet": {
       "version": "1.0.31",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-dotnet/-/dict-dotnet-1.0.31.tgz",
       "integrity": "sha512-65yZTMcEdYkNx9sNs18OxcE0zfbZ5VsAZ0KgDvl/1YCkTomxr9vmtnrzFz4+vxfjV4eSuaL1SPRMZODaM7SSTg==",
       "dev": true
     },
     "node_modules/@cspell/dict-elixir": {
       "version": "1.0.25",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-elixir/-/dict-elixir-1.0.25.tgz",
       "integrity": "sha512-ZmawoBYjM5k+8fNudRMkK+PpHjhyAFAZt2rUu1EGj2rbCvE3Fn2lhRbDjbreN7nWRvcLRTW+xuPXtKP11X0ahQ==",
       "dev": true
     },
     "node_modules/@cspell/dict-en_us": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-en_us/-/dict-en_us-2.1.0.tgz",
       "integrity": "sha512-c4ZpbBZwiO43eBSMFkbB6rdYUF9ruEExu2/iBr0M+3FIAAktUCkeLYT3VVkRCjnz4Oms8GzZBdDS7dmuSLSDgw==",
       "dev": true
     },
     "node_modules/@cspell/dict-en-gb": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-en-gb/-/dict-en-gb-2.0.1.tgz",
       "integrity": "sha512-YilaDSNCCaeRKAbL8m7/BaLslaTgoCXLRkhDBVav7hlFXCGKhg2af7kwIZXWMjMI/ihokqXHrms6eaL9zAZoZw==",
       "dev": true
     },
     "node_modules/@cspell/dict-filetypes": {
       "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-filetypes/-/dict-filetypes-1.1.8.tgz",
       "integrity": "sha512-EllahNkhzvLWo0ptwu0l3oEeAJOQSUpZnDfnKRIh6mJVehuSovNHwA9vrdZ8jBUjuqcfaN2e7c32zN0D/qvWJQ==",
       "dev": true
     },
     "node_modules/@cspell/dict-fonts": {
       "version": "1.0.14",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-fonts/-/dict-fonts-1.0.14.tgz",
       "integrity": "sha512-VhIX+FVYAnqQrOuoFEtya6+H72J82cIicz9QddgknsTqZQ3dvgp6lmVnsQXPM3EnzA8n1peTGpLDwHzT7ociLA==",
       "dev": true
     },
     "node_modules/@cspell/dict-fullstack": {
       "version": "1.0.38",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-fullstack/-/dict-fullstack-1.0.38.tgz",
       "integrity": "sha512-4reajWiUxwWrSyZaWm9e15kaWzjYcZbzlB+CVcxE1+0NqdIoqlEESDhbnrAjKPSq+jspKtes7nQ1CdZEOj1gCA==",
       "dev": true
     },
     "node_modules/@cspell/dict-golang": {
       "version": "1.1.24",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-golang/-/dict-golang-1.1.24.tgz",
       "integrity": "sha512-qq3Cjnx2U1jpeWAGJL1GL0ylEhUMqyaR36Xij6Y6Aq4bViCRp+HRRqk0x5/IHHbOrti45h3yy7ii1itRFo+Xkg==",
       "dev": true
     },
     "node_modules/@cspell/dict-haskell": {
       "version": "1.0.13",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-haskell/-/dict-haskell-1.0.13.tgz",
       "integrity": "sha512-kvl8T84cnYRPpND/P3D86P6WRSqebsbk0FnMfy27zo15L5MLAb3d3MOiT1kW3vEWfQgzUD7uddX/vUiuroQ8TA==",
       "dev": true
     },
     "node_modules/@cspell/dict-html": {
       "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-html/-/dict-html-1.1.9.tgz",
       "integrity": "sha512-vvnYia0tyIS5Fdoz+gEQm77MGZZE66kOJjuNpIYyRHCXFAhWdYz3SmkRm6YKJSWSvuO+WBJYTKDvkOxSh3Fx/w==",
       "dev": true
     },
     "node_modules/@cspell/dict-html-symbol-entities": {
       "version": "1.0.23",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-html-symbol-entities/-/dict-html-symbol-entities-1.0.23.tgz",
       "integrity": "sha512-PV0UBgcBFbBLf/m1wfkVMM8w96kvfHoiCGLWO6BR3Q9v70IXoE4ae0+T+f0CkxcEkacMqEQk/I7vuE9MzrjaNw==",
       "dev": true
     },
     "node_modules/@cspell/dict-java": {
       "version": "1.0.23",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-java/-/dict-java-1.0.23.tgz",
       "integrity": "sha512-LcOg9srYLDoNGd8n3kbfDBlZD+LOC9IVcnFCdua1b/luCHNVmlgBx7e677qPu7olpMYOD5TQIVW2OmM1+/6MFA==",
       "dev": true
     },
     "node_modules/@cspell/dict-latex": {
       "version": "1.0.25",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-latex/-/dict-latex-1.0.25.tgz",
       "integrity": "sha512-cEgg91Migqcp1SdVV7dUeMxbPDhxdNo6Fgq2eygAXQjIOFK520FFvh/qxyBvW90qdZbIRoU2AJpchyHfGuwZFA==",
       "dev": true
     },
     "node_modules/@cspell/dict-lorem-ipsum": {
       "version": "1.0.22",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-lorem-ipsum/-/dict-lorem-ipsum-1.0.22.tgz",
       "integrity": "sha512-yqzspR+2ADeAGUxLTfZ4pXvPl7FmkENMRcGDECmddkOiuEwBCWMZdMP5fng9B0Q6j91hQ8w9CLvJKBz10TqNYg==",
       "dev": true
     },
     "node_modules/@cspell/dict-lua": {
       "version": "1.0.16",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-lua/-/dict-lua-1.0.16.tgz",
       "integrity": "sha512-YiHDt8kmHJ8nSBy0tHzaxiuitYp+oJ66ffCYuFWTNB3//Y0SI4OGHU3omLsQVeXIfCeVrO4DrVvRDoCls9B5zQ==",
       "dev": true
     },
     "node_modules/@cspell/dict-node": {
       "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-node/-/dict-node-1.0.12.tgz",
       "integrity": "sha512-RPNn/7CSkflAWk0sbSoOkg0ORrgBARUjOW3QjB11KwV1gSu8f5W/ij/S50uIXtlrfoBLqd4OyE04jyON+g/Xfg==",
       "dev": true
     },
     "node_modules/@cspell/dict-npm": {
       "version": "1.0.16",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-npm/-/dict-npm-1.0.16.tgz",
       "integrity": "sha512-RwkuZGcYBxL3Yux3cSG/IOWGlQ1e9HLCpHeyMtTVGYKAIkFAVUnGrz20l16/Q7zUG7IEktBz5O42kAozrEnqMQ==",
       "dev": true
     },
     "node_modules/@cspell/dict-php": {
       "version": "1.0.24",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-php/-/dict-php-1.0.24.tgz",
       "integrity": "sha512-vHCqETX1idT9tN1plkxUFnXMIHjbbrNOINZh1PYSvVlBrOdahSaL/g6dOJZC5QTaaidoU4WXUlgnNb/7JN4Plg==",
       "dev": true
     },
     "node_modules/@cspell/dict-powershell": {
       "version": "1.0.18",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-powershell/-/dict-powershell-1.0.18.tgz",
       "integrity": "sha512-LAfCJBy1hga8/KI/IpAg/GrnoP+b4SbNGdiXiXrejeZ7ZTVfj4qYsTCkZ2p7eYUu92FLyJT4jGex0fGZn/PtVw==",
       "dev": true
     },
     "node_modules/@cspell/dict-public-licenses": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-public-licenses/-/dict-public-licenses-1.0.3.tgz",
       "integrity": "sha512-sXjxOHJ9Q4rZvE1UbwpwJQ8EXO3fadKBjJIWmz0z+dZAbvTrmz5Ln1Ef9ruJvLPfwAps8m3TCV6Diz60RAQqHg==",
       "dev": true
     },
     "node_modules/@cspell/dict-python": {
       "version": "1.0.37",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-python/-/dict-python-1.0.37.tgz",
       "integrity": "sha512-RPeYJxC7t6k9uL4aQp5kLarOddEAqfRw9VBTt+cOVSlMqEtEtxJGm8w91V28fwnRX4hQR0yhiHPEYcdLpMtpfQ==",
       "dev": true
     },
     "node_modules/@cspell/dict-ruby": {
       "version": "1.0.14",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-ruby/-/dict-ruby-1.0.14.tgz",
       "integrity": "sha512-XHBGN4U1y9rjRuqrCA+3yIm2TCdhwwHXpOEcWkNeyXm8K03yPnIrKFS+kap8GTTrLpfNDuFsrmkkQTa7ssXLRA==",
       "dev": true
     },
     "node_modules/@cspell/dict-rust": {
       "version": "1.0.23",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-rust/-/dict-rust-1.0.23.tgz",
       "integrity": "sha512-lR4boDzs79YD6+30mmiSGAMMdwh7HTBAPUFSB0obR3Kidibfc3GZ+MHWZXay5dxZ4nBKM06vyjtanF9VJ8q1Iw==",
       "dev": true
     },
     "node_modules/@cspell/dict-scala": {
       "version": "1.0.21",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-scala/-/dict-scala-1.0.21.tgz",
       "integrity": "sha512-5V/R7PRbbminTpPS3ywgdAalI9BHzcEjEj9ug4kWYvBIGwSnS7T6QCFCiu+e9LvEGUqQC+NHgLY4zs1NaBj2vA==",
       "dev": true
     },
     "node_modules/@cspell/dict-software-terms": {
       "version": "1.0.42",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-software-terms/-/dict-software-terms-1.0.42.tgz",
       "integrity": "sha512-VRIq7b6NnWVHeO0pzpHT10btQNYcRCyiSZc162xGlyO8+IMXq9Noemyqv+POS9oRknhtlF0rL1Hrg4ypHP3B+w==",
       "dev": true
     },
     "node_modules/@cspell/dict-typescript": {
       "version": "1.0.19",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-typescript/-/dict-typescript-1.0.19.tgz",
       "integrity": "sha512-qmJApzoVskDeJnLZzZMaafEDGbEg5Elt4c3Mpg49SWzIHm1N4VXCp5CcFfHsOinJ30dGrs3ARAJGJZIw56kK6A==",
       "dev": true
     },
     "node_modules/@types/parse-json": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
       "dev": true
     },
     "node_modules/abbrev": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
       "dev": true
     },
     "node_modules/ansi-regex": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
       "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
       "dev": true,
       "engines": {
@@ -378,7 +331,6 @@
     },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
       "dependencies": {
@@ -393,7 +345,6 @@
     },
     "node_modules/anymatch": {
       "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
       "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
       "dev": true,
       "dependencies": {
@@ -406,19 +357,16 @@
     },
     "node_modules/array-timsort": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/array-timsort/-/array-timsort-1.0.3.tgz",
       "integrity": "sha512-/+3GRL7dDAGEfM6TseQk/U+mi18TU2Ms9I3UlLdUMhz2hbvGNTKdj9xniwXfUqgYhHxRx0+8UnKkvlNwVU+cWQ==",
       "dev": true
     },
     "node_modules/balanced-match": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
     "node_modules/binary-extensions": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
       "dev": true,
       "engines": {
@@ -427,7 +375,6 @@
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "dependencies": {
@@ -437,7 +384,6 @@
     },
     "node_modules/braces": {
       "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
       "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
       "dev": true,
       "dependencies": {
@@ -449,7 +395,6 @@
     },
     "node_modules/callsites": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
       "dev": true,
       "engines": {
@@ -458,7 +403,6 @@
     },
     "node_modules/chokidar": {
       "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
       "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
       "dev": true,
       "funding": [
@@ -485,7 +429,6 @@
     },
     "node_modules/clear-module": {
       "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/clear-module/-/clear-module-4.1.1.tgz",
       "integrity": "sha512-ng0E7LeODcT3QkazOckzZqbca+JByQy/Q2Z6qO24YsTp+pLxCfohGz2gJYJqZS0CWTX3LEUiHOqe5KlYeUbEMw==",
       "dev": true,
       "dependencies": {
@@ -501,7 +444,6 @@
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
       "dependencies": {
@@ -513,13 +455,11 @@
     },
     "node_modules/color-name": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
     "node_modules/commander": {
       "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-8.2.0.tgz",
       "integrity": "sha512-LLKxDvHeL91/8MIyTAD5BFMNtoIwztGPMiM/7Bl8rIPmHCZXRxmSWr91h57dpOpnQ6jIUqEWdXE/uBYMfiVZDA==",
       "dev": true,
       "engines": {
@@ -528,7 +468,6 @@
     },
     "node_modules/comment-json": {
       "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/comment-json/-/comment-json-4.1.1.tgz",
       "integrity": "sha512-v8gmtPvxhBlhdRBLwdHSjGy9BgA23t9H1FctdQKyUrErPjSrJcdDMqBq9B4Irtm7w3TNYLQJNH6ARKnpyag1sA==",
       "dev": true,
       "dependencies": {
@@ -544,13 +483,11 @@
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
     "node_modules/configstore": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/configstore/-/configstore-5.0.1.tgz",
       "integrity": "sha512-aMKprgk5YhBNyH25hj8wGt2+D52Sw1DRRIzqBwLp2Ya9mFmY8KPvvtvmna8SxVR9JMZ4kzMD68N22vlaRpkeFA==",
       "dev": true,
       "dependencies": {
@@ -567,13 +504,11 @@
     },
     "node_modules/core-util-is": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "dev": true
     },
     "node_modules/cosmiconfig": {
       "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
       "integrity": "sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==",
       "dev": true,
       "dependencies": {
@@ -589,7 +524,6 @@
     },
     "node_modules/crypto-random-string": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
       "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==",
       "dev": true,
       "engines": {
@@ -598,7 +532,6 @@
     },
     "node_modules/cspell": {
       "version": "5.9.1",
-      "resolved": "https://registry.npmjs.org/cspell/-/cspell-5.9.1.tgz",
       "integrity": "sha512-4dec5W4K4c7TUREDfUYtcbwh70SL7oqkFim9XOpg3Ax0YadMZ8A4Xb8LKL+J7Egj/MqV+neMwomAakpWphDIrA==",
       "dev": true,
       "dependencies": {
@@ -625,7 +558,6 @@
     },
     "node_modules/cspell-glob": {
       "version": "5.9.1",
-      "resolved": "https://registry.npmjs.org/cspell-glob/-/cspell-glob-5.9.1.tgz",
       "integrity": "sha512-UtdXtwqX+K3jQ/8unIRQeqWW/tuTgbgiuojuw7C2xNURg5ZVDXODAa5v4cBZLJwkFnMZ2k4h+vSzk92NKwz7Cg==",
       "dev": true,
       "dependencies": {
@@ -637,7 +569,6 @@
     },
     "node_modules/cspell-io": {
       "version": "5.9.1",
-      "resolved": "https://registry.npmjs.org/cspell-io/-/cspell-io-5.9.1.tgz",
       "integrity": "sha512-sv71xxKjU0WKUO7w1OKZHtfMpQIu0cDgz480CkP7ptj+q10bwx6in6rHgAdE43+bvn2steZU7eVYas7MO785IA==",
       "dev": true,
       "engines": {
@@ -646,7 +577,6 @@
     },
     "node_modules/cspell-lib": {
       "version": "5.9.1",
-      "resolved": "https://registry.npmjs.org/cspell-lib/-/cspell-lib-5.9.1.tgz",
       "integrity": "sha512-qcU6T+yLgiVpC2MXVN9h30qDgSpBNdFUhui8NLpmcy9gjzcQX/uTCkc3h4gxQ/tyc6gxjh1CQVQ2Xg56pak3PA==",
       "dev": true,
       "dependencies": {
@@ -673,7 +603,6 @@
     },
     "node_modules/cspell-trie-lib": {
       "version": "5.9.1",
-      "resolved": "https://registry.npmjs.org/cspell-trie-lib/-/cspell-trie-lib-5.9.1.tgz",
       "integrity": "sha512-1A2S3KCOTPHQVP7mAC1uazfp7RPGVqdgQ2iqUPpux2hJRyH6fbweG6hNrV1oDPRYY7jMZPuA4aNqExe4/3IYgA==",
       "dev": true,
       "dependencies": {
@@ -686,7 +615,6 @@
     },
     "node_modules/cspell/node_modules/chalk": {
       "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
       "dependencies": {
@@ -702,7 +630,6 @@
     },
     "node_modules/cspell/node_modules/has-flag": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true,
       "engines": {
@@ -711,7 +638,6 @@
     },
     "node_modules/cspell/node_modules/supports-color": {
       "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dev": true,
       "dependencies": {
@@ -723,7 +649,6 @@
     },
     "node_modules/debug": {
       "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
       "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
       "dev": true,
       "dependencies": {
@@ -732,7 +657,6 @@
     },
     "node_modules/dot-prop": {
       "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
       "integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
       "dev": true,
       "dependencies": {
@@ -744,7 +668,6 @@
     },
     "node_modules/error-ex": {
       "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
       "dev": true,
       "dependencies": {
@@ -753,7 +676,6 @@
     },
     "node_modules/escape-string-regexp": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true,
       "engines": {
@@ -762,7 +684,6 @@
     },
     "node_modules/esprima": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "dev": true,
       "bin": {
@@ -775,7 +696,6 @@
     },
     "node_modules/fill-range": {
       "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
       "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
       "dev": true,
       "dependencies": {
@@ -787,7 +707,6 @@
     },
     "node_modules/find-up": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
       "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
       "dev": true,
       "dependencies": {
@@ -803,7 +722,6 @@
     },
     "node_modules/fs-extra": {
       "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
       "integrity": "sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==",
       "dev": true,
       "dependencies": {
@@ -817,13 +735,11 @@
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
     "node_modules/fsevents": {
       "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
       "dev": true,
       "hasInstallScript": true,
@@ -837,7 +753,6 @@
     },
     "node_modules/gensequence": {
       "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/gensequence/-/gensequence-3.1.1.tgz",
       "integrity": "sha512-ys3h0hiteRwmY6BsvSttPmkhC0vEQHPJduANBRtH/dlDPZ0UBIb/dXy80IcckXyuQ6LKg+PloRqvGER9IS7F7g==",
       "dev": true,
       "engines": {
@@ -846,7 +761,6 @@
     },
     "node_modules/get-stdin": {
       "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-8.0.0.tgz",
       "integrity": "sha512-sY22aA6xchAzprjyqmSEQv4UbAAzRN0L2dQB0NlN5acTTK9Don6nhoc3eAbUnpZiCANAMfd/+40kVdKfFygohg==",
       "dev": true,
       "engines": {
@@ -858,7 +772,6 @@
     },
     "node_modules/glob": {
       "version": "7.1.7",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
       "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
       "dev": true,
       "dependencies": {
@@ -878,7 +791,6 @@
     },
     "node_modules/glob-parent": {
       "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "dev": true,
       "dependencies": {
@@ -890,13 +802,11 @@
     },
     "node_modules/graceful-fs": {
       "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
       "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
       "dev": true
     },
     "node_modules/graphql": {
       "version": "17.0.0-alpha.9",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-17.0.0-alpha.9.tgz",
       "integrity": "sha512-jVK1BsvX5pUIEpRDlEgeKJr80GAxl3B8ISsFDjXHtl2xAxMXVGTEFF4Q4R8NH0Gw7yMwcHDndkNjoNT5CbwHKA==",
       "dev": true,
       "license": "MIT",
@@ -906,7 +816,6 @@
     },
     "node_modules/has-flag": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true,
       "engines": {
@@ -915,7 +824,6 @@
     },
     "node_modules/has-own-prop": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/has-own-prop/-/has-own-prop-2.0.0.tgz",
       "integrity": "sha512-Pq0h+hvsVm6dDEa8x82GnLSYHOzNDt7f0ddFa3FqcQlgzEiptPqL+XrOJNavjOzSYiYWIrgeVYYgGlLmnxwilQ==",
       "dev": true,
       "engines": {
@@ -924,13 +832,11 @@
     },
     "node_modules/ignore-by-default": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
       "integrity": "sha1-SMptcvbGo68Aqa1K5odr44ieKwk=",
       "dev": true
     },
     "node_modules/import-fresh": {
       "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
       "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
       "dev": true,
       "dependencies": {
@@ -946,7 +852,6 @@
     },
     "node_modules/import-fresh/node_modules/parent-module": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
       "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
       "dev": true,
       "dependencies": {
@@ -958,7 +863,6 @@
     },
     "node_modules/import-fresh/node_modules/resolve-from": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
       "dev": true,
       "engines": {
@@ -967,7 +871,6 @@
     },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
       "dev": true,
       "engines": {
@@ -976,7 +879,6 @@
     },
     "node_modules/inflight": {
       "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "dependencies": {
@@ -986,25 +888,21 @@
     },
     "node_modules/inherits": {
       "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
     },
     "node_modules/ini": {
       "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.7.tgz",
       "integrity": "sha512-iKpRpXP+CrP2jyrxvg1kMUpXDyRUFDWurxbnVT1vQPx+Wz9uCYsMIqYuSBLV+PAaZG/d7kRLKRFc9oDMsH+mFQ==",
       "dev": true
     },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
       "dev": true
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
       "dev": true,
       "dependencies": {
@@ -1016,7 +914,6 @@
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
       "dev": true,
       "engines": {
@@ -1025,7 +922,6 @@
     },
     "node_modules/is-glob": {
       "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
       "dev": true,
       "dependencies": {
@@ -1037,7 +933,6 @@
     },
     "node_modules/is-number": {
       "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "dev": true,
       "engines": {
@@ -1046,7 +941,6 @@
     },
     "node_modules/is-obj": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
       "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
       "dev": true,
       "engines": {
@@ -1055,25 +949,21 @@
     },
     "node_modules/is-typedarray": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
       "dev": true
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true
     },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true
     },
     "node_modules/jsonfile": {
       "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
       "dev": true,
       "dependencies": {
@@ -1085,13 +975,11 @@
     },
     "node_modules/lines-and-columns": {
       "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
       "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
       "dev": true
     },
     "node_modules/locate-path": {
       "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
       "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
       "dev": true,
       "dependencies": {
@@ -1106,7 +994,6 @@
     },
     "node_modules/make-dir": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
       "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
       "dev": true,
       "dependencies": {
@@ -1121,7 +1008,6 @@
     },
     "node_modules/make-dir/node_modules/semver": {
       "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
       "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
       "dev": true,
       "bin": {
@@ -1130,7 +1016,6 @@
     },
     "node_modules/micromatch": {
       "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
       "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
       "dev": true,
       "dependencies": {
@@ -1143,7 +1028,6 @@
     },
     "node_modules/minimatch": {
       "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
       "dependencies": {
@@ -1155,13 +1039,11 @@
     },
     "node_modules/ms": {
       "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true
     },
     "node_modules/nodemon": {
       "version": "2.0.20",
-      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-2.0.20.tgz",
       "integrity": "sha512-Km2mWHKKY5GzRg6i1j5OxOHQtuvVsgskLfigG25yTtbyfRGn/GNvIbRyOf1PSCKJ2aT/58TiuUsuOU5UToVViw==",
       "dev": true,
       "dependencies": {
@@ -1189,7 +1071,6 @@
     },
     "node_modules/nopt": {
       "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
       "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
       "dev": true,
       "dependencies": {
@@ -1204,7 +1085,6 @@
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true,
       "engines": {
@@ -1213,7 +1093,6 @@
     },
     "node_modules/once": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "dependencies": {
@@ -1222,7 +1101,6 @@
     },
     "node_modules/p-limit": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
       "dev": true,
       "dependencies": {
@@ -1237,7 +1115,6 @@
     },
     "node_modules/p-locate": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
       "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
       "dev": true,
       "dependencies": {
@@ -1252,7 +1129,6 @@
     },
     "node_modules/parent-module": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-2.0.0.tgz",
       "integrity": "sha512-uo0Z9JJeWzv8BG+tRcapBKNJ0dro9cLyczGzulS6EfeyAdeC9sbojtW6XwvYxJkEne9En+J2XEl4zyglVeIwFg==",
       "dev": true,
       "dependencies": {
@@ -1264,7 +1140,6 @@
     },
     "node_modules/parse-json": {
       "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
       "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
       "dev": true,
       "dependencies": {
@@ -1282,7 +1157,6 @@
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
       "dev": true,
       "engines": {
@@ -1291,7 +1165,6 @@
     },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true,
       "engines": {
@@ -1300,7 +1173,6 @@
     },
     "node_modules/path-type": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
       "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
       "dev": true,
       "engines": {
@@ -1309,7 +1181,6 @@
     },
     "node_modules/picomatch": {
       "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.3.tgz",
       "integrity": "sha512-KpELjfwcCDUb9PeigTs2mBJzXUPzAuP2oPcA989He8Rte0+YUAjw1JVedDhuTKPkHjSYzMN3npC9luThGYEKdg==",
       "dev": true,
       "engines": {
@@ -1321,7 +1192,6 @@
     },
     "node_modules/prettier": {
       "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.2.tgz",
       "integrity": "sha512-BtRV9BcncDyI2tsuS19zzhzoxD8Dh8LiCx7j7tHzrkz8GFXAexeWFdi22mjE1d16dftH2qNaytVxqiRTGlMfpw==",
       "dev": true,
       "bin": {
@@ -1336,19 +1206,16 @@
     },
     "node_modules/prismjs": {
       "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.24.1.tgz",
       "integrity": "sha512-mNPsedLuk90RVJioIky8ANZEwYm5w9LcvCXrxHlwf4fNVSn8jEipMybMkWUyyF0JhnC+C4VcOVSBuHRKs1L5Ow==",
       "dev": true
     },
     "node_modules/pstree.remy": {
       "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
       "integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==",
       "dev": true
     },
     "node_modules/readdirp": {
       "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
       "dev": true,
       "dependencies": {
@@ -1360,7 +1227,6 @@
     },
     "node_modules/repeat-string": {
       "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
       "dev": true,
       "engines": {
@@ -1369,7 +1235,6 @@
     },
     "node_modules/resolve-from": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
       "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
       "dev": true,
       "engines": {
@@ -1378,7 +1243,6 @@
     },
     "node_modules/resolve-global": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-global/-/resolve-global-1.0.0.tgz",
       "integrity": "sha512-zFa12V4OLtT5XUX/Q4VLvTfBf+Ok0SPc1FNGM/z9ctUdiU618qwKpWnd0CHs3+RqROfyEg/DhuHbMWYqcgljEw==",
       "dev": true,
       "dependencies": {
@@ -1390,7 +1254,6 @@
     },
     "node_modules/resolve-global/node_modules/global-dirs": {
       "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
       "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
       "dev": true,
       "dependencies": {
@@ -1402,7 +1265,6 @@
     },
     "node_modules/semver": {
       "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
       "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
       "dev": true,
       "bin": {
@@ -1411,13 +1273,11 @@
     },
     "node_modules/signal-exit": {
       "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
       "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
       "dev": true
     },
     "node_modules/simple-update-notifier": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-1.1.0.tgz",
       "integrity": "sha512-VpsrsJSUcJEseSbMHkrsrAVSdvVS5I96Qo1QAQ4FxQ9wXFcB+pjj7FB7/us9+GcgfW4ziHtYMc1J0PLczb55mg==",
       "dev": true,
       "dependencies": {
@@ -1429,7 +1289,6 @@
     },
     "node_modules/simple-update-notifier/node_modules/semver": {
       "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz",
       "integrity": "sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==",
       "dev": true,
       "bin": {
@@ -1438,7 +1297,6 @@
     },
     "node_modules/spec-md": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/spec-md/-/spec-md-3.1.0.tgz",
       "integrity": "sha512-h4/Pc+ICB+q8cXKTyy8f5JJHSQRNy1oh05P/vTrq+qIV2fLmEaalwpZMRYMzlq/g+qxnIp/hywGGYA3rpefYmA==",
       "dev": true,
       "dependencies": {
@@ -1453,7 +1311,6 @@
     },
     "node_modules/strip-ansi": {
       "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
       "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
       "dev": true,
       "dependencies": {
@@ -1465,7 +1322,6 @@
     },
     "node_modules/supports-color": {
       "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
       "dev": true,
       "dependencies": {
@@ -1477,7 +1333,6 @@
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
       "dev": true,
       "dependencies": {
@@ -1489,7 +1344,6 @@
     },
     "node_modules/touch": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/touch/-/touch-3.1.0.tgz",
       "integrity": "sha512-WBx8Uy5TLtOSRtIq+M03/sKDrXCLHxwDcquSP2c43Le03/9serjQBIztjRz6FkJez9D/hleyAXTBGLwwZUw9lA==",
       "dev": true,
       "dependencies": {
@@ -1501,7 +1355,6 @@
     },
     "node_modules/typedarray-to-buffer": {
       "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
       "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
       "dev": true,
       "dependencies": {
@@ -1510,13 +1363,11 @@
     },
     "node_modules/undefsafe": {
       "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
       "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
       "dev": true
     },
     "node_modules/unique-string": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-2.0.0.tgz",
       "integrity": "sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==",
       "dev": true,
       "dependencies": {
@@ -1528,7 +1379,6 @@
     },
     "node_modules/universalify": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
       "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
       "dev": true,
       "engines": {
@@ -1537,19 +1387,16 @@
     },
     "node_modules/vscode-uri": {
       "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.2.tgz",
       "integrity": "sha512-jkjy6pjU1fxUvI51P+gCsxg1u2n8LSt0W6KrCNQceaziKzff74GoWmjVG46KieVzybO1sttPQmYfrwSHey7GUA==",
       "dev": true
     },
     "node_modules/wrappy": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
     },
     "node_modules/write-file-atomic": {
       "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
       "integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
       "dev": true,
       "dependencies": {
@@ -1561,7 +1408,6 @@
     },
     "node_modules/xdg-basedir": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-4.0.0.tgz",
       "integrity": "sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==",
       "dev": true,
       "engines": {
@@ -1570,7 +1416,6 @@
     },
     "node_modules/yaml": {
       "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
       "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
       "dev": true,
       "engines": {
@@ -1579,7 +1424,6 @@
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true,
       "engines": {
@@ -1593,7 +1437,6 @@
   "dependencies": {
     "@babel/code-frame": {
       "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
       "integrity": "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==",
       "dev": true,
       "requires": {
@@ -1602,13 +1445,11 @@
     },
     "@babel/helper-validator-identifier": {
       "version": "7.14.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz",
       "integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g==",
       "dev": true
     },
     "@babel/highlight": {
       "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
       "integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
       "dev": true,
       "requires": {
@@ -1619,7 +1460,6 @@
       "dependencies": {
         "ansi-styles": {
           "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
@@ -1628,7 +1468,6 @@
         },
         "chalk": {
           "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
@@ -1639,7 +1478,6 @@
         },
         "color-convert": {
           "version": "1.9.3",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
           "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
           "dev": true,
           "requires": {
@@ -1648,7 +1486,6 @@
         },
         "color-name": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
           "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
           "dev": true
         }
@@ -1656,7 +1493,6 @@
     },
     "@cspell/cspell-bundled-dicts": {
       "version": "5.9.1",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-bundled-dicts/-/cspell-bundled-dicts-5.9.1.tgz",
       "integrity": "sha512-xnLHhqb5BdfnVrLDZIdfPKlsNt4OKgvWx6T/MpS5pC7/Unqjcj3Do1fVDNlJ/nmxWkWPJnWDc6c6yQWC1kEnuw==",
       "dev": true,
       "requires": {
@@ -1699,241 +1535,201 @@
     },
     "@cspell/cspell-types": {
       "version": "5.9.1",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-types/-/cspell-types-5.9.1.tgz",
       "integrity": "sha512-h8CWnGAKtItJG5FkoD+6BICfH7LqLi1GdiiF6IP1ZcRbWFybmgV/Y8Vj7KvKlkG7enw3IIJKHln4UxFB7UV5qw==",
       "dev": true
     },
     "@cspell/dict-ada": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-ada/-/dict-ada-1.1.2.tgz",
       "integrity": "sha512-UDrcYcKIVyXDz5mInJabRNQpJoehjBFvja5W+GQyu9pGcx3BS3cAU8mWENstGR0Qc/iFTxB010qwF8F3cHA/aA==",
       "dev": true
     },
     "@cspell/dict-aws": {
       "version": "1.0.14",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-aws/-/dict-aws-1.0.14.tgz",
       "integrity": "sha512-K21CfB4ZpKYwwDQiPfic2zJA/uxkbsd4IQGejEvDAhE3z8wBs6g6BwwqdVO767M9NgZqc021yAVpr79N5pWe3w==",
       "dev": true
     },
     "@cspell/dict-bash": {
       "version": "1.0.15",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-bash/-/dict-bash-1.0.15.tgz",
       "integrity": "sha512-rY5Bq4RWTgJTioG8vqFbCmnalc/UEM+iBuAZBYvBfT3nU/6SN00Zjyvlh823ir2ODkUryT29CwRYwXcPnuM04w==",
       "dev": true
     },
     "@cspell/dict-companies": {
       "version": "1.0.40",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-companies/-/dict-companies-1.0.40.tgz",
       "integrity": "sha512-Aw07qiTroqSST2P5joSrC4uOA05zTXzI2wMb+me3q4Davv1D9sCkzXY0TGoC2vzhNv5ooemRi9KATGaBSdU1sw==",
       "dev": true
     },
     "@cspell/dict-cpp": {
       "version": "1.1.40",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-cpp/-/dict-cpp-1.1.40.tgz",
       "integrity": "sha512-sscfB3woNDNj60/yGXAdwNtIRWZ89y35xnIaJVDMk5TPMMpaDvuk0a34iOPIq0g4V+Y8e3RyAg71SH6ADwSjGw==",
       "dev": true
     },
     "@cspell/dict-cryptocurrencies": {
       "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-cryptocurrencies/-/dict-cryptocurrencies-1.0.10.tgz",
       "integrity": "sha512-47ABvDJOkaST/rXipNMfNvneHUzASvmL6K/CbOFpYKfsd0x23Jc9k1yaOC7JAm82XSC/8a7+3Yu+Fk2jVJNnsA==",
       "dev": true
     },
     "@cspell/dict-csharp": {
       "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-csharp/-/dict-csharp-1.0.11.tgz",
       "integrity": "sha512-nub+ZCiTgmT87O+swI+FIAzNwaZPWUGckJU4GN402wBq420V+F4ZFqNV7dVALJrGaWH7LvADRtJxi6cZVHJKeA==",
       "dev": true
     },
     "@cspell/dict-css": {
       "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-css/-/dict-css-1.0.12.tgz",
       "integrity": "sha512-K6yuxej7n454O7dwKG6lHacHrAOMZ0PhMEbmV6qH2JH0U4TtWXfBASYugHvXZCDDx1UObpiJP+3tQJiBqfGpHA==",
       "dev": true
     },
     "@cspell/dict-django": {
       "version": "1.0.26",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-django/-/dict-django-1.0.26.tgz",
       "integrity": "sha512-mn9bd7Et1L2zuibc08GVHTiD2Go3/hdjyX5KLukXDklBkq06r+tb0OtKtf1zKodtFDTIaYekGADhNhA6AnKLkg==",
       "dev": true
     },
     "@cspell/dict-dotnet": {
       "version": "1.0.31",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-dotnet/-/dict-dotnet-1.0.31.tgz",
       "integrity": "sha512-65yZTMcEdYkNx9sNs18OxcE0zfbZ5VsAZ0KgDvl/1YCkTomxr9vmtnrzFz4+vxfjV4eSuaL1SPRMZODaM7SSTg==",
       "dev": true
     },
     "@cspell/dict-elixir": {
       "version": "1.0.25",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-elixir/-/dict-elixir-1.0.25.tgz",
       "integrity": "sha512-ZmawoBYjM5k+8fNudRMkK+PpHjhyAFAZt2rUu1EGj2rbCvE3Fn2lhRbDjbreN7nWRvcLRTW+xuPXtKP11X0ahQ==",
       "dev": true
     },
     "@cspell/dict-en_us": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-en_us/-/dict-en_us-2.1.0.tgz",
       "integrity": "sha512-c4ZpbBZwiO43eBSMFkbB6rdYUF9ruEExu2/iBr0M+3FIAAktUCkeLYT3VVkRCjnz4Oms8GzZBdDS7dmuSLSDgw==",
       "dev": true
     },
     "@cspell/dict-en-gb": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-en-gb/-/dict-en-gb-2.0.1.tgz",
       "integrity": "sha512-YilaDSNCCaeRKAbL8m7/BaLslaTgoCXLRkhDBVav7hlFXCGKhg2af7kwIZXWMjMI/ihokqXHrms6eaL9zAZoZw==",
       "dev": true
     },
     "@cspell/dict-filetypes": {
       "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-filetypes/-/dict-filetypes-1.1.8.tgz",
       "integrity": "sha512-EllahNkhzvLWo0ptwu0l3oEeAJOQSUpZnDfnKRIh6mJVehuSovNHwA9vrdZ8jBUjuqcfaN2e7c32zN0D/qvWJQ==",
       "dev": true
     },
     "@cspell/dict-fonts": {
       "version": "1.0.14",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-fonts/-/dict-fonts-1.0.14.tgz",
       "integrity": "sha512-VhIX+FVYAnqQrOuoFEtya6+H72J82cIicz9QddgknsTqZQ3dvgp6lmVnsQXPM3EnzA8n1peTGpLDwHzT7ociLA==",
       "dev": true
     },
     "@cspell/dict-fullstack": {
       "version": "1.0.38",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-fullstack/-/dict-fullstack-1.0.38.tgz",
       "integrity": "sha512-4reajWiUxwWrSyZaWm9e15kaWzjYcZbzlB+CVcxE1+0NqdIoqlEESDhbnrAjKPSq+jspKtes7nQ1CdZEOj1gCA==",
       "dev": true
     },
     "@cspell/dict-golang": {
       "version": "1.1.24",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-golang/-/dict-golang-1.1.24.tgz",
       "integrity": "sha512-qq3Cjnx2U1jpeWAGJL1GL0ylEhUMqyaR36Xij6Y6Aq4bViCRp+HRRqk0x5/IHHbOrti45h3yy7ii1itRFo+Xkg==",
       "dev": true
     },
     "@cspell/dict-haskell": {
       "version": "1.0.13",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-haskell/-/dict-haskell-1.0.13.tgz",
       "integrity": "sha512-kvl8T84cnYRPpND/P3D86P6WRSqebsbk0FnMfy27zo15L5MLAb3d3MOiT1kW3vEWfQgzUD7uddX/vUiuroQ8TA==",
       "dev": true
     },
     "@cspell/dict-html": {
       "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-html/-/dict-html-1.1.9.tgz",
       "integrity": "sha512-vvnYia0tyIS5Fdoz+gEQm77MGZZE66kOJjuNpIYyRHCXFAhWdYz3SmkRm6YKJSWSvuO+WBJYTKDvkOxSh3Fx/w==",
       "dev": true
     },
     "@cspell/dict-html-symbol-entities": {
       "version": "1.0.23",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-html-symbol-entities/-/dict-html-symbol-entities-1.0.23.tgz",
       "integrity": "sha512-PV0UBgcBFbBLf/m1wfkVMM8w96kvfHoiCGLWO6BR3Q9v70IXoE4ae0+T+f0CkxcEkacMqEQk/I7vuE9MzrjaNw==",
       "dev": true
     },
     "@cspell/dict-java": {
       "version": "1.0.23",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-java/-/dict-java-1.0.23.tgz",
       "integrity": "sha512-LcOg9srYLDoNGd8n3kbfDBlZD+LOC9IVcnFCdua1b/luCHNVmlgBx7e677qPu7olpMYOD5TQIVW2OmM1+/6MFA==",
       "dev": true
     },
     "@cspell/dict-latex": {
       "version": "1.0.25",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-latex/-/dict-latex-1.0.25.tgz",
       "integrity": "sha512-cEgg91Migqcp1SdVV7dUeMxbPDhxdNo6Fgq2eygAXQjIOFK520FFvh/qxyBvW90qdZbIRoU2AJpchyHfGuwZFA==",
       "dev": true
     },
     "@cspell/dict-lorem-ipsum": {
       "version": "1.0.22",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-lorem-ipsum/-/dict-lorem-ipsum-1.0.22.tgz",
       "integrity": "sha512-yqzspR+2ADeAGUxLTfZ4pXvPl7FmkENMRcGDECmddkOiuEwBCWMZdMP5fng9B0Q6j91hQ8w9CLvJKBz10TqNYg==",
       "dev": true
     },
     "@cspell/dict-lua": {
       "version": "1.0.16",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-lua/-/dict-lua-1.0.16.tgz",
       "integrity": "sha512-YiHDt8kmHJ8nSBy0tHzaxiuitYp+oJ66ffCYuFWTNB3//Y0SI4OGHU3omLsQVeXIfCeVrO4DrVvRDoCls9B5zQ==",
       "dev": true
     },
     "@cspell/dict-node": {
       "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-node/-/dict-node-1.0.12.tgz",
       "integrity": "sha512-RPNn/7CSkflAWk0sbSoOkg0ORrgBARUjOW3QjB11KwV1gSu8f5W/ij/S50uIXtlrfoBLqd4OyE04jyON+g/Xfg==",
       "dev": true
     },
     "@cspell/dict-npm": {
       "version": "1.0.16",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-npm/-/dict-npm-1.0.16.tgz",
       "integrity": "sha512-RwkuZGcYBxL3Yux3cSG/IOWGlQ1e9HLCpHeyMtTVGYKAIkFAVUnGrz20l16/Q7zUG7IEktBz5O42kAozrEnqMQ==",
       "dev": true
     },
     "@cspell/dict-php": {
       "version": "1.0.24",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-php/-/dict-php-1.0.24.tgz",
       "integrity": "sha512-vHCqETX1idT9tN1plkxUFnXMIHjbbrNOINZh1PYSvVlBrOdahSaL/g6dOJZC5QTaaidoU4WXUlgnNb/7JN4Plg==",
       "dev": true
     },
     "@cspell/dict-powershell": {
       "version": "1.0.18",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-powershell/-/dict-powershell-1.0.18.tgz",
       "integrity": "sha512-LAfCJBy1hga8/KI/IpAg/GrnoP+b4SbNGdiXiXrejeZ7ZTVfj4qYsTCkZ2p7eYUu92FLyJT4jGex0fGZn/PtVw==",
       "dev": true
     },
     "@cspell/dict-public-licenses": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-public-licenses/-/dict-public-licenses-1.0.3.tgz",
       "integrity": "sha512-sXjxOHJ9Q4rZvE1UbwpwJQ8EXO3fadKBjJIWmz0z+dZAbvTrmz5Ln1Ef9ruJvLPfwAps8m3TCV6Diz60RAQqHg==",
       "dev": true
     },
     "@cspell/dict-python": {
       "version": "1.0.37",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-python/-/dict-python-1.0.37.tgz",
       "integrity": "sha512-RPeYJxC7t6k9uL4aQp5kLarOddEAqfRw9VBTt+cOVSlMqEtEtxJGm8w91V28fwnRX4hQR0yhiHPEYcdLpMtpfQ==",
       "dev": true
     },
     "@cspell/dict-ruby": {
       "version": "1.0.14",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-ruby/-/dict-ruby-1.0.14.tgz",
       "integrity": "sha512-XHBGN4U1y9rjRuqrCA+3yIm2TCdhwwHXpOEcWkNeyXm8K03yPnIrKFS+kap8GTTrLpfNDuFsrmkkQTa7ssXLRA==",
       "dev": true
     },
     "@cspell/dict-rust": {
       "version": "1.0.23",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-rust/-/dict-rust-1.0.23.tgz",
       "integrity": "sha512-lR4boDzs79YD6+30mmiSGAMMdwh7HTBAPUFSB0obR3Kidibfc3GZ+MHWZXay5dxZ4nBKM06vyjtanF9VJ8q1Iw==",
       "dev": true
     },
     "@cspell/dict-scala": {
       "version": "1.0.21",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-scala/-/dict-scala-1.0.21.tgz",
       "integrity": "sha512-5V/R7PRbbminTpPS3ywgdAalI9BHzcEjEj9ug4kWYvBIGwSnS7T6QCFCiu+e9LvEGUqQC+NHgLY4zs1NaBj2vA==",
       "dev": true
     },
     "@cspell/dict-software-terms": {
       "version": "1.0.42",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-software-terms/-/dict-software-terms-1.0.42.tgz",
       "integrity": "sha512-VRIq7b6NnWVHeO0pzpHT10btQNYcRCyiSZc162xGlyO8+IMXq9Noemyqv+POS9oRknhtlF0rL1Hrg4ypHP3B+w==",
       "dev": true
     },
     "@cspell/dict-typescript": {
       "version": "1.0.19",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-typescript/-/dict-typescript-1.0.19.tgz",
       "integrity": "sha512-qmJApzoVskDeJnLZzZMaafEDGbEg5Elt4c3Mpg49SWzIHm1N4VXCp5CcFfHsOinJ30dGrs3ARAJGJZIw56kK6A==",
       "dev": true
     },
     "@types/parse-json": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
       "dev": true
     },
     "abbrev": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
       "dev": true
     },
     "ansi-regex": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
       "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
       "dev": true
     },
     "ansi-styles": {
       "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
       "requires": {
@@ -1942,7 +1738,6 @@
     },
     "anymatch": {
       "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
       "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
       "dev": true,
       "requires": {
@@ -1952,25 +1747,21 @@
     },
     "array-timsort": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/array-timsort/-/array-timsort-1.0.3.tgz",
       "integrity": "sha512-/+3GRL7dDAGEfM6TseQk/U+mi18TU2Ms9I3UlLdUMhz2hbvGNTKdj9xniwXfUqgYhHxRx0+8UnKkvlNwVU+cWQ==",
       "dev": true
     },
     "balanced-match": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
     "binary-extensions": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
       "dev": true
     },
     "brace-expansion": {
       "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "requires": {
@@ -1980,7 +1771,6 @@
     },
     "braces": {
       "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
       "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
       "dev": true,
       "requires": {
@@ -1989,13 +1779,11 @@
     },
     "callsites": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
       "dev": true
     },
     "chokidar": {
       "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
       "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
       "dev": true,
       "requires": {
@@ -2011,7 +1799,6 @@
     },
     "clear-module": {
       "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/clear-module/-/clear-module-4.1.1.tgz",
       "integrity": "sha512-ng0E7LeODcT3QkazOckzZqbca+JByQy/Q2Z6qO24YsTp+pLxCfohGz2gJYJqZS0CWTX3LEUiHOqe5KlYeUbEMw==",
       "dev": true,
       "requires": {
@@ -2021,7 +1808,6 @@
     },
     "color-convert": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
       "requires": {
@@ -2030,19 +1816,16 @@
     },
     "color-name": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
     "commander": {
       "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-8.2.0.tgz",
       "integrity": "sha512-LLKxDvHeL91/8MIyTAD5BFMNtoIwztGPMiM/7Bl8rIPmHCZXRxmSWr91h57dpOpnQ6jIUqEWdXE/uBYMfiVZDA==",
       "dev": true
     },
     "comment-json": {
       "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/comment-json/-/comment-json-4.1.1.tgz",
       "integrity": "sha512-v8gmtPvxhBlhdRBLwdHSjGy9BgA23t9H1FctdQKyUrErPjSrJcdDMqBq9B4Irtm7w3TNYLQJNH6ARKnpyag1sA==",
       "dev": true,
       "requires": {
@@ -2055,13 +1838,11 @@
     },
     "concat-map": {
       "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
     "configstore": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/configstore/-/configstore-5.0.1.tgz",
       "integrity": "sha512-aMKprgk5YhBNyH25hj8wGt2+D52Sw1DRRIzqBwLp2Ya9mFmY8KPvvtvmna8SxVR9JMZ4kzMD68N22vlaRpkeFA==",
       "dev": true,
       "requires": {
@@ -2075,13 +1856,11 @@
     },
     "core-util-is": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "dev": true
     },
     "cosmiconfig": {
       "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
       "integrity": "sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==",
       "dev": true,
       "requires": {
@@ -2094,13 +1873,11 @@
     },
     "crypto-random-string": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
       "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==",
       "dev": true
     },
     "cspell": {
       "version": "5.9.1",
-      "resolved": "https://registry.npmjs.org/cspell/-/cspell-5.9.1.tgz",
       "integrity": "sha512-4dec5W4K4c7TUREDfUYtcbwh70SL7oqkFim9XOpg3Ax0YadMZ8A4Xb8LKL+J7Egj/MqV+neMwomAakpWphDIrA==",
       "dev": true,
       "requires": {
@@ -2118,7 +1895,6 @@
       "dependencies": {
         "chalk": {
           "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
           "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "dev": true,
           "requires": {
@@ -2128,13 +1904,11 @@
         },
         "has-flag": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
         },
         "supports-color": {
           "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
           "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "dev": true,
           "requires": {
@@ -2145,7 +1919,6 @@
     },
     "cspell-glob": {
       "version": "5.9.1",
-      "resolved": "https://registry.npmjs.org/cspell-glob/-/cspell-glob-5.9.1.tgz",
       "integrity": "sha512-UtdXtwqX+K3jQ/8unIRQeqWW/tuTgbgiuojuw7C2xNURg5ZVDXODAa5v4cBZLJwkFnMZ2k4h+vSzk92NKwz7Cg==",
       "dev": true,
       "requires": {
@@ -2154,13 +1927,11 @@
     },
     "cspell-io": {
       "version": "5.9.1",
-      "resolved": "https://registry.npmjs.org/cspell-io/-/cspell-io-5.9.1.tgz",
       "integrity": "sha512-sv71xxKjU0WKUO7w1OKZHtfMpQIu0cDgz480CkP7ptj+q10bwx6in6rHgAdE43+bvn2steZU7eVYas7MO785IA==",
       "dev": true
     },
     "cspell-lib": {
       "version": "5.9.1",
-      "resolved": "https://registry.npmjs.org/cspell-lib/-/cspell-lib-5.9.1.tgz",
       "integrity": "sha512-qcU6T+yLgiVpC2MXVN9h30qDgSpBNdFUhui8NLpmcy9gjzcQX/uTCkc3h4gxQ/tyc6gxjh1CQVQ2Xg56pak3PA==",
       "dev": true,
       "requires": {
@@ -2184,7 +1955,6 @@
     },
     "cspell-trie-lib": {
       "version": "5.9.1",
-      "resolved": "https://registry.npmjs.org/cspell-trie-lib/-/cspell-trie-lib-5.9.1.tgz",
       "integrity": "sha512-1A2S3KCOTPHQVP7mAC1uazfp7RPGVqdgQ2iqUPpux2hJRyH6fbweG6hNrV1oDPRYY7jMZPuA4aNqExe4/3IYgA==",
       "dev": true,
       "requires": {
@@ -2194,7 +1964,6 @@
     },
     "debug": {
       "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
       "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
       "dev": true,
       "requires": {
@@ -2203,7 +1972,6 @@
     },
     "dot-prop": {
       "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
       "integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
       "dev": true,
       "requires": {
@@ -2212,7 +1980,6 @@
     },
     "error-ex": {
       "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
       "dev": true,
       "requires": {
@@ -2221,19 +1988,16 @@
     },
     "escape-string-regexp": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
     },
     "esprima": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "dev": true
     },
     "fill-range": {
       "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
       "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
       "dev": true,
       "requires": {
@@ -2242,7 +2006,6 @@
     },
     "find-up": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
       "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
       "dev": true,
       "requires": {
@@ -2252,7 +2015,6 @@
     },
     "fs-extra": {
       "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
       "integrity": "sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==",
       "dev": true,
       "requires": {
@@ -2263,32 +2025,27 @@
     },
     "fs.realpath": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
     "fsevents": {
       "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
       "dev": true,
       "optional": true
     },
     "gensequence": {
       "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/gensequence/-/gensequence-3.1.1.tgz",
       "integrity": "sha512-ys3h0hiteRwmY6BsvSttPmkhC0vEQHPJduANBRtH/dlDPZ0UBIb/dXy80IcckXyuQ6LKg+PloRqvGER9IS7F7g==",
       "dev": true
     },
     "get-stdin": {
       "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-8.0.0.tgz",
       "integrity": "sha512-sY22aA6xchAzprjyqmSEQv4UbAAzRN0L2dQB0NlN5acTTK9Don6nhoc3eAbUnpZiCANAMfd/+40kVdKfFygohg==",
       "dev": true
     },
     "glob": {
       "version": "7.1.7",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
       "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
       "dev": true,
       "requires": {
@@ -2302,7 +2059,6 @@
     },
     "glob-parent": {
       "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "dev": true,
       "requires": {
@@ -2311,37 +2067,31 @@
     },
     "graceful-fs": {
       "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
       "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
       "dev": true
     },
     "graphql": {
       "version": "17.0.0-alpha.9",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-17.0.0-alpha.9.tgz",
       "integrity": "sha512-jVK1BsvX5pUIEpRDlEgeKJr80GAxl3B8ISsFDjXHtl2xAxMXVGTEFF4Q4R8NH0Gw7yMwcHDndkNjoNT5CbwHKA==",
       "dev": true
     },
     "has-flag": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true
     },
     "has-own-prop": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/has-own-prop/-/has-own-prop-2.0.0.tgz",
       "integrity": "sha512-Pq0h+hvsVm6dDEa8x82GnLSYHOzNDt7f0ddFa3FqcQlgzEiptPqL+XrOJNavjOzSYiYWIrgeVYYgGlLmnxwilQ==",
       "dev": true
     },
     "ignore-by-default": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
       "integrity": "sha1-SMptcvbGo68Aqa1K5odr44ieKwk=",
       "dev": true
     },
     "import-fresh": {
       "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
       "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
       "dev": true,
       "requires": {
@@ -2351,7 +2101,6 @@
       "dependencies": {
         "parent-module": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
           "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
           "dev": true,
           "requires": {
@@ -2360,7 +2109,6 @@
         },
         "resolve-from": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
           "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
           "dev": true
         }
@@ -2368,13 +2116,11 @@
     },
     "imurmurhash": {
       "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
       "dev": true
     },
     "inflight": {
       "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
@@ -2384,25 +2130,21 @@
     },
     "inherits": {
       "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
     },
     "ini": {
       "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.7.tgz",
       "integrity": "sha512-iKpRpXP+CrP2jyrxvg1kMUpXDyRUFDWurxbnVT1vQPx+Wz9uCYsMIqYuSBLV+PAaZG/d7kRLKRFc9oDMsH+mFQ==",
       "dev": true
     },
     "is-arrayish": {
       "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
       "dev": true
     },
     "is-binary-path": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
       "dev": true,
       "requires": {
@@ -2411,13 +2153,11 @@
     },
     "is-extglob": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
       "dev": true
     },
     "is-glob": {
       "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
       "dev": true,
       "requires": {
@@ -2426,37 +2166,31 @@
     },
     "is-number": {
       "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "dev": true
     },
     "is-obj": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
       "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
       "dev": true
     },
     "is-typedarray": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
       "dev": true
     },
     "js-tokens": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true
     },
     "json-parse-even-better-errors": {
       "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true
     },
     "jsonfile": {
       "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
       "dev": true,
       "requires": {
@@ -2466,13 +2200,11 @@
     },
     "lines-and-columns": {
       "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
       "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
       "dev": true
     },
     "locate-path": {
       "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
       "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
       "dev": true,
       "requires": {
@@ -2481,7 +2213,6 @@
     },
     "make-dir": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
       "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
       "dev": true,
       "requires": {
@@ -2490,7 +2221,6 @@
       "dependencies": {
         "semver": {
           "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
           "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
           "dev": true
         }
@@ -2498,7 +2228,6 @@
     },
     "micromatch": {
       "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
       "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
       "dev": true,
       "requires": {
@@ -2508,7 +2237,6 @@
     },
     "minimatch": {
       "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
       "requires": {
@@ -2517,13 +2245,11 @@
     },
     "ms": {
       "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true
     },
     "nodemon": {
       "version": "2.0.20",
-      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-2.0.20.tgz",
       "integrity": "sha512-Km2mWHKKY5GzRg6i1j5OxOHQtuvVsgskLfigG25yTtbyfRGn/GNvIbRyOf1PSCKJ2aT/58TiuUsuOU5UToVViw==",
       "dev": true,
       "requires": {
@@ -2541,7 +2267,6 @@
     },
     "nopt": {
       "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
       "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
       "dev": true,
       "requires": {
@@ -2550,13 +2275,11 @@
     },
     "normalize-path": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true
     },
     "once": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
@@ -2565,7 +2288,6 @@
     },
     "p-limit": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
       "dev": true,
       "requires": {
@@ -2574,7 +2296,6 @@
     },
     "p-locate": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
       "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
       "dev": true,
       "requires": {
@@ -2583,7 +2304,6 @@
     },
     "parent-module": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-2.0.0.tgz",
       "integrity": "sha512-uo0Z9JJeWzv8BG+tRcapBKNJ0dro9cLyczGzulS6EfeyAdeC9sbojtW6XwvYxJkEne9En+J2XEl4zyglVeIwFg==",
       "dev": true,
       "requires": {
@@ -2592,7 +2312,6 @@
     },
     "parse-json": {
       "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
       "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
       "dev": true,
       "requires": {
@@ -2604,49 +2323,41 @@
     },
     "path-exists": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
       "dev": true
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
     "path-type": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
       "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
       "dev": true
     },
     "picomatch": {
       "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.3.tgz",
       "integrity": "sha512-KpELjfwcCDUb9PeigTs2mBJzXUPzAuP2oPcA989He8Rte0+YUAjw1JVedDhuTKPkHjSYzMN3npC9luThGYEKdg==",
       "dev": true
     },
     "prettier": {
       "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.2.tgz",
       "integrity": "sha512-BtRV9BcncDyI2tsuS19zzhzoxD8Dh8LiCx7j7tHzrkz8GFXAexeWFdi22mjE1d16dftH2qNaytVxqiRTGlMfpw==",
       "dev": true
     },
     "prismjs": {
       "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.24.1.tgz",
       "integrity": "sha512-mNPsedLuk90RVJioIky8ANZEwYm5w9LcvCXrxHlwf4fNVSn8jEipMybMkWUyyF0JhnC+C4VcOVSBuHRKs1L5Ow==",
       "dev": true
     },
     "pstree.remy": {
       "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
       "integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==",
       "dev": true
     },
     "readdirp": {
       "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
       "dev": true,
       "requires": {
@@ -2655,19 +2366,16 @@
     },
     "repeat-string": {
       "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
       "dev": true
     },
     "resolve-from": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
       "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
       "dev": true
     },
     "resolve-global": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-global/-/resolve-global-1.0.0.tgz",
       "integrity": "sha512-zFa12V4OLtT5XUX/Q4VLvTfBf+Ok0SPc1FNGM/z9ctUdiU618qwKpWnd0CHs3+RqROfyEg/DhuHbMWYqcgljEw==",
       "dev": true,
       "requires": {
@@ -2676,7 +2384,6 @@
       "dependencies": {
         "global-dirs": {
           "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
           "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
           "dev": true,
           "requires": {
@@ -2687,19 +2394,16 @@
     },
     "semver": {
       "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
       "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
       "dev": true
     },
     "signal-exit": {
       "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
       "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
       "dev": true
     },
     "simple-update-notifier": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-1.1.0.tgz",
       "integrity": "sha512-VpsrsJSUcJEseSbMHkrsrAVSdvVS5I96Qo1QAQ4FxQ9wXFcB+pjj7FB7/us9+GcgfW4ziHtYMc1J0PLczb55mg==",
       "dev": true,
       "requires": {
@@ -2708,7 +2412,6 @@
       "dependencies": {
         "semver": {
           "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz",
           "integrity": "sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==",
           "dev": true
         }
@@ -2716,7 +2419,6 @@
     },
     "spec-md": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/spec-md/-/spec-md-3.1.0.tgz",
       "integrity": "sha512-h4/Pc+ICB+q8cXKTyy8f5JJHSQRNy1oh05P/vTrq+qIV2fLmEaalwpZMRYMzlq/g+qxnIp/hywGGYA3rpefYmA==",
       "dev": true,
       "requires": {
@@ -2725,7 +2427,6 @@
     },
     "strip-ansi": {
       "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
       "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
       "dev": true,
       "requires": {
@@ -2734,7 +2435,6 @@
     },
     "supports-color": {
       "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
       "dev": true,
       "requires": {
@@ -2743,7 +2443,6 @@
     },
     "to-regex-range": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
       "dev": true,
       "requires": {
@@ -2752,7 +2451,6 @@
     },
     "touch": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/touch/-/touch-3.1.0.tgz",
       "integrity": "sha512-WBx8Uy5TLtOSRtIq+M03/sKDrXCLHxwDcquSP2c43Le03/9serjQBIztjRz6FkJez9D/hleyAXTBGLwwZUw9lA==",
       "dev": true,
       "requires": {
@@ -2761,7 +2459,6 @@
     },
     "typedarray-to-buffer": {
       "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
       "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
       "dev": true,
       "requires": {
@@ -2770,13 +2467,11 @@
     },
     "undefsafe": {
       "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
       "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
       "dev": true
     },
     "unique-string": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-2.0.0.tgz",
       "integrity": "sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==",
       "dev": true,
       "requires": {
@@ -2785,25 +2480,21 @@
     },
     "universalify": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
       "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
       "dev": true
     },
     "vscode-uri": {
       "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.2.tgz",
       "integrity": "sha512-jkjy6pjU1fxUvI51P+gCsxg1u2n8LSt0W6KrCNQceaziKzff74GoWmjVG46KieVzybO1sttPQmYfrwSHey7GUA==",
       "dev": true
     },
     "wrappy": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
     },
     "write-file-atomic": {
       "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
       "integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
       "dev": true,
       "requires": {
@@ -2815,19 +2506,16 @@
     },
     "xdg-basedir": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-4.0.0.tgz",
       "integrity": "sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==",
       "dev": true
     },
     "yaml": {
       "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
       "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
       "dev": true
     },
     "yocto-queue": {
       "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true
     }

--- a/spec/Section 2 -- Language.md
+++ b/spec/Section 2 -- Language.md
@@ -1481,14 +1481,14 @@ MemberCoordinate :: Name . Name
 
 1. Let {typeName} be the value of the first {Name}.
 2. Let {type} be the type in {schema} named {typeName}.
-3. Assert: {type} must exist, and must be an Enum, Input Object, Object or
-   Interface type.
+3. Assert: {type} must exist, and must be an Enum, Input Object, Struct, Object
+   or Interface type.
 4. If {type} is an Enum type:
    1. Let {enumValueName} be the value of the second {Name}.
    2. Return the enum value of {type} named {enumValueName} if it exists.
-5. Otherwise, if {type} is an Input Object type:
-   1. Let {inputFieldName} be the value of the second {Name}.
-   2. Return the input field of {type} named {inputFieldName} if it exists.
+5. Otherwise, if {type} is an Input Object or Struct type:
+   1. Let {fieldName} be the value of the second {Name}.
+   2. Return the field of {type} named {fieldName} if it exists.
 6. Otherwise:
    1. Let {fieldName} be the value of the second {Name}.
    2. Return the field of {type} named {fieldName} if it exists.

--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -311,8 +311,9 @@ TypeDefinition :
 - UnionTypeDefinition
 - EnumTypeDefinition
 - InputObjectTypeDefinition
+- StructTypeDefinition
 
-The fundamental unit of any GraphQL Schema is the type. There are six kinds of
+The fundamental unit of any GraphQL Schema is the type. There are seven kinds of
 named type definitions in GraphQL, and two wrapping types.
 
 The most basic type is a `Scalar`. A scalar represents a primitive value, like a
@@ -335,9 +336,15 @@ A `Union` defines a list of possible types; similar to interfaces, whenever the
 type system claims a union will be returned, one of the possible types will be
 returned.
 
+A `Struct` defines a set of named fields that can appear in both input and
+output positions. Unlike Object types, struct fields do not have resolvers and
+selection sets are optional in output position (omitting a selection set returns
+all fields). The `Input Object` type is a deprecated alias for `Struct` that
+remains for backwards compatibility.
+
 Finally, oftentimes it is useful to provide complex structs as inputs to GraphQL
-field arguments or variables; the `Input Object` type allows the schema to
-define exactly what data is expected.
+field arguments or variables; the `Struct` type allows the schema to define
+exactly what data is expected.
 
 ### Wrapping Types
 
@@ -361,17 +368,18 @@ Types are used throughout GraphQL to describe both the values accepted as input
 to arguments and variables as well as the values output by fields. These two
 uses categorize types as _input types_ and _output types_. Some kinds of types,
 like Scalar and Enum types, can be used as both input types and output types;
-other kinds of types can only be used in one or the other. Input Object types
-can only be used as input types. Object, Interface, and Union types can only be
-used as output types. Lists and Non-Null types may be used as input types or
-output types depending on how the wrapped type may be used.
+other kinds of types can only be used in one or the other. Struct types (and
+their deprecated alias, Input Object types) can be used as both input types and
+output types. Object, Interface, and Union types can only be used as output
+types. Lists and Non-Null types may be used as input types or output types
+depending on how the wrapped type may be used.
 
 IsInputType(type):
 
 - If {type} is a List type or Non-Null type:
   - Let {unwrappedType} be the unwrapped type of {type}.
   - Return {IsInputType(unwrappedType)}.
-- If {type} is a Scalar, Enum, or Input Object type:
+- If {type} is a Scalar, Enum, Input Object, or Struct type:
   - Return {true}.
 - Return {false}.
 
@@ -380,7 +388,7 @@ IsOutputType(type):
 - If {type} is a List type or Non-Null type:
   - Let {unwrappedType} be the unwrapped type of {type}.
   - Return {IsOutputType(unwrappedType)}.
-- If {type} is a Scalar, Object, Interface, Union, or Enum type:
+- If {type} is a Scalar, Object, Interface, Union, Enum, or Struct type:
   - Return {true}.
 - Return {false}.
 
@@ -394,6 +402,7 @@ TypeExtension :
 - UnionTypeExtension
 - EnumTypeExtension
 - InputObjectTypeExtension
+- StructTypeExtension
 
 Type extensions are used to represent a GraphQL type which has been extended
 from some previous type. For example, this might be used by a local service to
@@ -1453,9 +1462,12 @@ Unions are never valid inputs.
 Union types have the potential to be invalid if incorrectly defined.
 
 1. A Union type must include one or more unique member types.
-2. The member types of a Union type must all be Object base types; Scalar,
-   Interface and Union types must not be member types of a Union. Similarly,
-   wrapping types must not be member types of a Union.
+2. The member types of a Union type must all be Object or Struct base types;
+   Scalar, Interface and Union types must not be member types of a Union.
+   Similarly, wrapping types must not be member types of a Union.
+3. The member types of a Union type must be homogeneous: either all Object types
+   or all Struct types. A union must not contain a mix of Object and Struct
+   member types.
 
 ### Union Extensions
 
@@ -1864,6 +1876,284 @@ defined.
    2. All fields of the Input Object type extension must not have default
       values.
 
+## Structs
+
+StructTypeDefinition :
+
+- Description? struct Name Directives[Const]? StructFieldsDefinition?
+- Description? struct Name Directives[Const]? [lookahead != `{`]
+
+StructFieldsDefinition : { StructFieldDefinition+ }
+
+StructFieldDefinition : Description? Name : Type DefaultValue?
+Directives[Const]?
+
+:: A GraphQL _Struct_ defines a set of named fields. Unlike Object types, struct
+fields do not accept arguments and do not have individual resolvers. Structs can
+appear in both input and output positions, making them suitable for representing
+structured data that flows symmetrically through a GraphQL schema.
+
+The `struct` keyword is the canonical way to define structured input/output
+types. The `input` keyword is a deprecated alias that produces an Input Object
+type with equivalent semantics in input position but without output-position
+capabilities.
+
+In this example, a Struct called `Point2D` describes `x` and `y` fields:
+
+```graphql example
+struct Point2D {
+  x: Float
+  y: Float
+}
+```
+
+A struct can be used as a field return type and as an argument type:
+
+```graphql example
+type Query {
+  origin: Point2D
+  distance(from: Point2D!, to: Point2D!): Float
+}
+```
+
+When a field returns a struct, the selection set is optional. Omitting the
+selection set returns all fields of the struct (wildcard selection):
+
+```graphql example
+{
+  origin
+}
+```
+
+This is equivalent to explicitly selecting all fields:
+
+```graphql example
+{
+  origin {
+    x
+    y
+  }
+}
+```
+
+**Circular References**
+
+Structs are allowed to reference other Structs as field types. A circular
+reference occurs when a Struct references itself either directly or through
+referenced Structs.
+
+Circular references are generally allowed, however they may not be defined as an
+unbroken chain of Non-Null singular fields. Such Structs are invalid because
+there is no way to provide a legal value for them.
+
+This example of a circularly-referenced struct type is valid as the field `self`
+may be omitted or the value {null}.
+
+```graphql example
+struct Example {
+  self: Example
+  value: String
+}
+```
+
+This example of a circularly-referenced struct type is invalid as the field
+`self` cannot be provided a finite value.
+
+```graphql counter-example
+struct Example {
+  self: Example!
+  value: String
+}
+```
+
+**Result Coercion**
+
+When a struct type is the return type of a field, the resolved value must be an
+unordered map of field names to values. Each field value is coerced according to
+the result coercion rules of that field's type.
+
+**Input Coercion**
+
+The value for a struct should be an input object literal or an unordered map
+supplied by a variable, otherwise a _request error_ must be raised. In either
+case, the input object literal or unordered map must not contain any entries
+with names not defined by a field of this struct type, otherwise a request error
+must be raised.
+
+The result of coercion is an unordered map with an entry for each field both
+defined by the struct type and for which a value exists. The resulting map is
+constructed with the following rules:
+
+- If no value is provided for a defined struct field and that field definition
+  provides a default value, the result of coercing the default value according
+  to the coercion rules of the field type should be used. If no default value is
+  provided and the struct field's type is non-null, an error should be raised.
+  Otherwise, if the field is not required, then no entry is added to the coerced
+  unordered map.
+
+- If the value {null} was provided for a struct field, and the field's type is
+  not a non-null type, an entry in the coerced unordered map is given the value
+  {null}. In other words, there is a semantic difference between the explicitly
+  provided value {null} versus having not provided a value.
+
+- If a literal value is provided for a struct field, an entry in the coerced
+  unordered map is given the result of coercing that value according to the
+  input coercion rules for the type of that field.
+
+- If a variable is provided for a struct field, the runtime value of that
+  variable must be used. If the runtime value is {null} and the field type is
+  non-null, an _execution error_ must be raised. If no runtime value is
+  provided, the variable definition's default value should be used. If the
+  variable definition does not provide a default value, the struct field
+  definition's default value should be used.
+
+**Wildcard Selection**
+
+When a field's return type is a Struct type and no selection set is provided,
+all fields of the struct are implicitly selected (wildcard selection). This is
+equivalent to writing a selection set that selects every field of the struct.
+
+For struct fields whose type is also a Struct, wildcard selection applies
+recursively.
+
+When a field's return type is a Union of Struct types (a _struct union_) and no
+selection set is provided, all fields are returned along with the `__typename`
+meta-field to allow type discrimination.
+
+**Struct Unions**
+
+:: A _struct union_ is a Union type whose member types are all Struct types. In
+a struct union, the `__typename` meta-field is available to discriminate between
+members.
+
+When querying a struct union field without a selection set, the result includes
+`__typename` and all fields of the resolved struct member.
+
+```graphql example
+struct Circle {
+  radius: Float
+}
+
+struct Rectangle {
+  width: Float
+  height: Float
+}
+
+union Shape = Circle | Rectangle
+
+type Query {
+  shape: Shape
+}
+```
+
+A query may omit the selection set for wildcard behavior:
+
+```graphql example
+{
+  shape
+}
+```
+
+Or use typed fragments for specific fields:
+
+```graphql example
+{
+  shape {
+    __typename
+    ... on Circle {
+      radius
+    }
+    ... on Rectangle {
+      width
+      height
+    }
+  }
+}
+```
+
+**Type Validation**
+
+1. A Struct type must define one or more fields.
+2. For each field of a Struct type:
+   1. The field must have a unique name within that Struct type; no two fields
+      may share the same name.
+   2. The field must not have a name which begins with the characters {"\_\_"}
+      (two underscores).
+   3. The field must accept a type where {IsInputType(fieldType)} returns
+      {true}.
+   4. If field type is Non-Null and a default value is not defined:
+      1. The `@deprecated` directive must not be applied to this field.
+   5. If the Struct is a _OneOf Struct_ then:
+      1. The type of the field must be nullable.
+      2. The field must not have a default value.
+3. If a Struct references itself either directly or through referenced Structs,
+   at least one of the fields in the chain of references must be either a
+   nullable or a List type.
+
+### OneOf Structs
+
+:: A _OneOf Struct_ is a special variant of _Struct_ where exactly one field
+must be set and non-null, all others being omitted. This is useful for
+representing situations where an input may be one of many different options.
+
+When using the type system definition language, the [`@oneOf`](#sec--oneOf)
+directive is used to indicate that a Struct is a OneOf Struct (and thus requires
+exactly one of its fields be provided):
+
+```graphql
+struct UserUniqueCondition @oneOf {
+  id: ID
+  username: String
+  organizationAndEmail: OrganizationAndEmailInput
+}
+```
+
+In schema introspection, the `__Type.isOneOf` field will return {true} for OneOf
+Structs, and {false} for all other Structs.
+
+**Input Coercion**
+
+The value of a OneOf Struct, as a variant of Struct, must also be an input
+object literal or an unordered map supplied by a variable, otherwise a _request
+error_ must be raised.
+
+- Prior to construction of the coerced map via the input coercion rules of a
+  _Struct_: the value to be coerced must contain exactly one entry and that
+  entry must not be {null} or the {null} literal, otherwise a _request error_
+  must be raised.
+
+- All _Struct_ [input coercion rules](#sec-Structs.Input-Coercion) must also
+  apply to a _OneOf Struct_.
+
+- The resulting coerced map must contain exactly one entry and the value for
+  that entry must not be {null}, otherwise an _execution error_ must be raised.
+
+### Struct Extensions
+
+StructTypeExtension :
+
+- extend struct Name Directives[Const]? StructFieldsDefinition
+- extend struct Name Directives[Const] [lookahead != `{`]
+
+Struct type extensions are used to represent a struct type which has been
+extended from some previous struct type. For example, this might be used by a
+GraphQL service which is itself an extension of another GraphQL service.
+
+**Type Validation**
+
+Struct type extensions have the potential to be invalid if incorrectly defined.
+
+1. The named type must already be defined and must be a Struct type.
+2. All fields of a Struct type extension must have unique names.
+3. All fields of a Struct type extension must not already be a field of the
+   previous Struct.
+4. Any non-repeatable directives provided must not already apply to the previous
+   Struct type.
+5. The `@oneOf` directive must not be provided by a Struct type extension.
+6. If the original Struct is a _OneOf Struct_ then:
+   1. All fields of the Struct type extension must be nullable.
+   2. All fields of the Struct type extension must not have default values.
+
 ## List
 
 A GraphQL list is a special collection type which declares the type of each item
@@ -2070,6 +2360,8 @@ TypeSystemDirectiveLocation : one of
 - `ENUM_VALUE`
 - `INPUT_OBJECT`
 - `INPUT_FIELD_DEFINITION`
+- `STRUCT`
+- `STRUCT_FIELD_DEFINITION`
 - `DIRECTIVE_DEFINITION`
 
 A GraphQL schema describes directives which are used to annotate various parts
@@ -2310,11 +2602,12 @@ scalar UUID @specifiedBy(url: "https://tools.ietf.org/html/rfc4122")
 ### @oneOf
 
 ```graphql
-directive @oneOf on INPUT_OBJECT
+directive @oneOf on INPUT_OBJECT | STRUCT
 ```
 
 The `@oneOf` _built-in directive_ is used within the type system definition
-language to indicate an _Input Object_ is a _OneOf Input Object_.
+language to indicate an _Input Object_ is a _OneOf Input Object_ or a _Struct_
+is a _OneOf Struct_.
 
 ```graphql example
 input UserUniqueCondition @oneOf {

--- a/spec/Section 4 -- Introspection.md
+++ b/spec/Section 4 -- Introspection.md
@@ -147,7 +147,7 @@ type __Type {
   description: String
   # may be non-null for custom SCALAR, otherwise null.
   specifiedByURL: String
-  # must be non-null for OBJECT and INTERFACE, otherwise null.
+  # must be non-null for OBJECT, INTERFACE, and STRUCT, otherwise null.
   fields(includeDeprecated: Boolean! = false): [__Field!]
   # must be non-null for OBJECT and INTERFACE, otherwise null.
   interfaces: [__Type!]
@@ -155,11 +155,11 @@ type __Type {
   possibleTypes: [__Type!]
   # must be non-null for ENUM, otherwise null.
   enumValues(includeDeprecated: Boolean! = false): [__EnumValue!]
-  # must be non-null for INPUT_OBJECT, otherwise null.
+  # must be non-null for INPUT_OBJECT and STRUCT, otherwise null.
   inputFields(includeDeprecated: Boolean! = false): [__InputValue!]
   # must be non-null for NON_NULL and LIST, otherwise null.
   ofType: __Type
-  # must be non-null for INPUT_OBJECT, otherwise null.
+  # must be non-null for INPUT_OBJECT and STRUCT, otherwise null.
   isOneOf: Boolean
 }
 
@@ -169,7 +169,8 @@ enum __TypeKind {
   INTERFACE
   UNION
   ENUM
-  INPUT_OBJECT
+  INPUT_OBJECT @deprecated(reason: "Use STRUCT.")
+  STRUCT
   LIST
   NON_NULL
 }
@@ -229,6 +230,8 @@ enum __DirectiveLocation {
   ENUM_VALUE
   INPUT_OBJECT
   INPUT_FIELD_DEFINITION
+  STRUCT
+  STRUCT_FIELD_DEFINITION
   DIRECTIVE_DEFINITION
 }
 ```
@@ -276,6 +279,7 @@ possible value of the `__TypeKind` enum:
 - {"UNION"}
 - {"ENUM"}
 - {"INPUT_OBJECT"}
+- {"STRUCT"}
 - {"LIST"}
 - {"NON_NULL"}
 
@@ -367,9 +371,10 @@ Fields\:
 
 **Input Object**
 
-Input objects are composite types defined as a list of named input values. They
-are only used as inputs to arguments and variables and cannot be a field return
-type.
+Input objects are composite types defined as a list of named input values. The
+`input` keyword is a deprecated alias for `struct`; types defined with `input`
+report kind `INPUT_OBJECT` for backwards compatibility. New schemas should use
+the `struct` keyword instead.
 
 For example the input object `Point` could be defined as:
 
@@ -390,6 +395,38 @@ Fields\:
     {true}, deprecated input fields are also returned.
 - `isOneOf` must return {true} when representing a _OneOf Input Object_,
   otherwise {false}.
+- All other fields must return {null}.
+
+**Struct**
+
+Structs are composite types that can appear in both input and output positions.
+They define a set of named fields without per-field resolvers. Types defined
+with the `struct` keyword report kind `STRUCT`.
+
+For example the struct `Point` could be defined as:
+
+```graphql example
+struct Point {
+  x: Int
+  y: Int
+}
+```
+
+Fields\:
+
+- `kind` must return `__TypeKind.STRUCT`.
+- `name` must return a String.
+- `description` may return a String or {null}.
+- `fields` must return the set of fields as a list of `__Field`. These fields do
+  not accept arguments.
+  - Accepts the argument `includeDeprecated` which defaults to {false}. If
+    {true}, deprecated fields are also returned.
+- `inputFields` must return the set of fields as a list of `__InputValue` (for
+  backwards compatibility with clients that query input fields).
+  - Accepts the argument `includeDeprecated` which defaults to {false}. If
+    {true}, deprecated fields are also returned.
+- `isOneOf` must return {true} when representing a _OneOf Struct_, otherwise
+  {false}.
 - All other fields must return {null}.
 
 **List**

--- a/spec/Section 5 -- Validation.md
+++ b/spec/Section 5 -- Validation.md
@@ -723,6 +723,8 @@ fragment conflictingDifferingResponses on Pet {
     - The subselection set of that selection must be empty.
   - If {selectionType} is an interface, union, or object:
     - The subselection set of that selection must not be empty.
+  - If {selectionType} is a struct:
+    - The subselection set of that selection may be empty (wildcard selection).
 
 **Explanatory Text**
 
@@ -748,7 +750,9 @@ fragment scalarSelectionsNotAllowedOnInt on Dog {
 ```
 
 Conversely, non-leaf fields must have a field subselection. A non-leaf field is
-any field with an object, interface, or union unwrapped type.
+any field with an object, interface, or union unwrapped type. Struct fields are
+an exception: a subselection set is optional, and omitting it selects all fields
+(wildcard selection).
 
 Let's assume the following additions to the query root operation type of the
 schema:
@@ -785,6 +789,24 @@ query directQueryOnObjectWithSubFields {
   human {
     name
   }
+}
+```
+
+Fields returning a Struct type may omit the subselection set. Both of the
+following are valid:
+
+```graphql example
+query structWithSubSelection {
+  origin {
+    x
+    y
+  }
+}
+```
+
+```graphql example
+query structWithWildcard {
+  origin
 }
 ```
 

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -843,11 +843,18 @@ CompleteValue(fieldType, fields, result, variableValues):
     {resultItem} is each item in {result}.
 - If {fieldType} is a Scalar or Enum type:
   - Return the result of {CoerceResult(fieldType, result)}.
+- If {fieldType} is a Struct type:
+  - Return the result of {CompleteStructValue(fieldType, fields, result,
+    variableValues)}.
 - If {fieldType} is an Object, Interface, or Union type:
   - If {fieldType} is an Object type.
     - Let {objectType} be {fieldType}.
   - Otherwise if {fieldType} is an Interface or Union type.
-    - Let {objectType} be {ResolveAbstractType(fieldType, result)}.
+    - Let {resolvedType} be {ResolveAbstractType(fieldType, result)}.
+    - If {resolvedType} is a Struct type:
+      - Return the result of {CompleteStructValue(resolvedType, fields, result,
+        variableValues)}.
+    - Let {objectType} be {resolvedType}.
   - Let {collectedFieldsMap} be the result of calling
     {CollectSubfields(objectType, fields, variableValues)}.
   - Return the result of evaluating {ExecuteCollectedFields(collectedFieldsMap,
@@ -878,12 +885,63 @@ Note: If a field resolver returns {null} then it is handled within
 {CompleteValue()} before {CoerceResult()} is called. Therefore both the input
 and output of {CoerceResult()} must not be {null}.
 
+**Completing Struct Values**
+
+When a field's return type is a Struct type, the resolved value is completed by
+returning its fields. Unlike Object types, struct fields do not have individual
+resolvers; the resolved value is an unordered map whose entries correspond to
+the struct's defined fields.
+
+CompleteStructValue(structType, fields, result, variableValues):
+
+- Assert: {result} is an unordered map.
+- Let {firstField} be the first entry in {fields}.
+- Let {selectionSet} be the selection set of {firstField}.
+- If {selectionSet} is empty (wildcard selection):
+  - Let {completedResult} be a new unordered map.
+  - For each {structField} defined on {structType}:
+    - Let {fieldName} be the name of {structField}.
+    - Let {fieldType} be the type of {structField}.
+    - Let {fieldValue} be the value for {fieldName} in {result}, or {null} if
+      not present.
+    - Let {completedFieldValue} be the result of calling
+      {CompleteValue(fieldType, fields, fieldValue, variableValues)} where
+      {fields} contains only a synthetic field entry for {fieldName} with an
+      empty selection set.
+    - Add an entry to {completedResult} named {fieldName} with the value
+      {completedFieldValue}.
+  - If {structType} is a member of a Union type, add an entry {"\_\_typename"}
+    with the value being the name of {structType}.
+  - Return {completedResult}.
+- Otherwise:
+  - Let {completedResult} be a new unordered map.
+  - Let {collectedFieldsMap} be the result of collecting fields from
+    {selectionSet} given {structType} and {variableValues}.
+  - For each {collectedFieldsMap} as {responseName} and {collectedFields}:
+    - Let {fieldName} be the name of the first entry in {collectedFields}.
+    - If {fieldName} is {"\_\_typename"}:
+      - Add an entry to {completedResult} named {responseName} with the value
+        being the name of {structType}.
+    - Otherwise:
+      - Let {structField} be the field of {structType} named {fieldName}.
+      - Let {fieldType} be the type of {structField}.
+      - Let {fieldValue} be the value for {fieldName} in {result}, or {null} if
+        not present.
+      - Let {completedFieldValue} be the result of calling
+        {CompleteValue(fieldType, collectedFields, fieldValue, variableValues)}.
+      - Add an entry to {completedResult} named {responseName} with the value
+        {completedFieldValue}.
+  - Return {completedResult}.
+
 **Resolving Abstract Types**
 
 When completing a field with an abstract return type, that is an Interface or
 Union return type, first the abstract type must be resolved to a relevant Object
-type. This determination is made by the internal system using whatever means
-appropriate.
+or Struct type. This determination is made by the internal system using whatever
+means appropriate.
+
+For a Union whose members are all Struct types (a _struct union_), the resolved
+type must be one of the Struct member types.
 
 Note: A common method of determining the Object type for an {objectValue} in
 object-oriented environments, such as Java or C#, is to use the class name of
@@ -892,7 +950,7 @@ the {objectValue}.
 ResolveAbstractType(abstractType, objectValue):
 
 - Return the result of calling the internal method provided by the type system
-  for determining the Object type of {abstractType} given the value
+  for determining the Object or Struct type of {abstractType} given the value
   {objectValue}.
 
 ### Handling Execution Errors


### PR DESCRIPTION
## Summary

- `struct` keyword replaces `input` as the canonical structured data type
- Structs are both input AND output types (symmetric transput)
- `input` keyword remains as deprecated alias
- Selection sets on struct-typed output fields are optional (wildcard returns full value)
- Struct unions: existing `union` keyword, homogeneity enforced (all-objects or all-structs)
- Introspection: `STRUCT` kind added, `INPUT_OBJECT` deprecated

## Motivation

Solves the "star selector" problem for SDUI and structured data use cases,
while also unifying input/output type definitions under a single keyword.
See: https://github.com/graphql/graphql-wg/blob/main/rfcs/Struct.md

## TODO

- [ ] Appendix C (Grammar Summary) update deferred to a follow-up PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)